### PR TITLE
Fixed the first issue in #118

### DIFF
--- a/src/common/elist.h
+++ b/src/common/elist.h
@@ -79,6 +79,11 @@ namespace pvpgn
 			iterator(const iterator& orig) :ptr(orig.ptr) {}
 			~iterator() throw() {}
 
+			iterator& operator=(const iterator& i) {
+                ptr = i.ptr;
+                return *this;
+			}
+
 			bool operator==(const iterator& op) const {
 				return ptr == op.ptr;
 			}

--- a/src/common/elist.h
+++ b/src/common/elist.h
@@ -80,8 +80,8 @@ namespace pvpgn
 			~iterator() throw() {}
 
 			iterator& operator=(const iterator& i) {
-                ptr = i.ptr;
-                return *this;
+				ptr = i.ptr;
+				return *this;
 			}
 
 			bool operator==(const iterator& op) const {


### PR DESCRIPTION
This fixes the first error in issue #118.  You need an equals operator when you have a copy constructor (line 79).  While it is not used, it will make the compiler happy.