### PR TITLE
Fix compile error when MFC is not installed

### DIFF
--- a/src/win32/d2cs_resource.rc
+++ b/src/win32/d2cs_resource.rc
@@ -3,7 +3,11 @@
 
 #define APSTUDIO_READONLY_SYMBOLS
 #ifndef __BORLANDC__
+#ifdef __AFXRES_H__
 #include "afxres.h"
+#else
+#include "winres.h"
+#endif //__AFXRES_H__
 #endif
 
 /* Menu */

--- a/src/win32/d2dbs_resource.rc
+++ b/src/win32/d2dbs_resource.rc
@@ -3,8 +3,12 @@
 
 #define APSTUDIO_READONLY_SYMBOLS
 #ifndef __BORLANDC__
+#ifdef __AFXRES_H__
 #include "afxres.h"
-#endif
+#else
+#include "winres.h"
+#endif //__AFXRES_H__
+#endif //__BORLANDC__
 
 /* Menu */
 ID_MENU MENU DISCARDABLE 

--- a/src/win32/resource.rc
+++ b/src/win32/resource.rc
@@ -9,7 +9,11 @@
 // Generated from the TEXTINCLUDE 2 resource.
 //
 #ifndef __BORLANDC__
+#ifdef __AFXRES_H__
 #include "afxres.h"
+#else
+#include "winres.h"
+#endif //__AFXRES_H__
 #endif
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Checks if ````__AFXRES_H__```` is defined(which means MFC is installed) before including ````afxres.h````. If MFC is not installed, ````winres.h```` will substitute it.